### PR TITLE
just remove the extre '}'

### DIFF
--- a/CommandParser.cs
+++ b/CommandParser.cs
@@ -11,7 +11,6 @@ namespace ProjectDover
                 Console.WriteLine("Did you mean `quit`?");
                 return Command.COMMAND_HANDLED;
             }
-            }
 
             if (commandText.Equals("QUIT", StringComparison.OrdinalIgnoreCase))
             {


### PR DESCRIPTION
Just fixing a little typo, so you don't spend time looking for it.